### PR TITLE
Fix warning due to 'undefined' constant

### DIFF
--- a/ascii_table.php
+++ b/ascii_table.php
@@ -53,7 +53,7 @@ class ascii_table{
             for($i=0;$i<$longest_cell;$i++){
                 $new_row_temp = array();
                 foreach($row_array as $col => $col_data){
-                    if($col_data[$i]!=undefined){
+                    if(isset($col_data[$i])){
                         $new_row_temp[$col] = trim($col_data[$i]);
                     }else{
                         $new_row_temp[$col] = '';


### PR DESCRIPTION
My PHP (7.2) was issuing a warning in the line [56](https://github.com/pgooch/PHP-Ascii-Tables/blob/7c183208487f2952b3137c9e5d79e46b41bd40cf/ascii_table.php#L56) due to comparisson with the "undefined" constant.

Changed the comparisson to use isset().