### PR TITLE
Add autoloading, namespaces and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+/composer.lock
+.DS_Store
+._*

--- a/ascii_table.php
+++ b/ascii_table.php
@@ -1,4 +1,6 @@
 <?php
+namespace Ascii_Table;
+
 /**
  * PHP ASCII Tables
  *

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pgooch/php-ascii-tables",
     "version": "1.1.0",
     "type": "library",
-    "description": "Convert multi-dimensional arrays into ASCII Tabled, and vise-versa.",
+    "description": "Convert multi-dimensional arrays into ASCII Tables and vise-versa.",
     "keywords": ["cli","ascii","tables"],
     "homepage": "https://github.com/pgooch/PHP-Ascii-Tables",
     "license": "GPLv3",
@@ -15,6 +15,11 @@
         }
     ],
     "require": {
-        "php": ">=5.0.0"
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ascii_Table\\": ""
+        }
     }
 }

--- a/examples.php
+++ b/examples.php
@@ -1,6 +1,7 @@
 <?php
-require_once('./ascii_table.php');
-$ascii_table = new ascii_table();
+require_once 'vendor/autoload.php';
+
+$ascii_table = new Ascii_Table\Ascii_Table();
 // Colors Example Data
 $svg_colors = array(
    array(


### PR DESCRIPTION
It's cool that the lib is available on Packagist, but it's not cool that one can't autoload the library using Composer's autoloader. This patch fixes that by namespacing the library and creating PSR-4 autoloading rules.

*Note that this is a breaking change.*